### PR TITLE
Fix like button counter not updating

### DIFF
--- a/frontend/public/js/player.js
+++ b/frontend/public/js/player.js
@@ -433,7 +433,7 @@ async function toggleLike() {
     likeBtn.disabled = true;
 
     try {
-        const response = await fetch('http://localhost:5001/api/tracks/like', {
+        const response = await fetch('/api/tracks/like', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -470,7 +470,7 @@ async function checkAndUpdateLikeStatus(trackIdentifier) {
     }
 
     try {
-        const response = await fetch('http://localhost:5001/api/tracks/is-liked', {
+        const response = await fetch('/api/tracks/is-liked', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -6,7 +6,7 @@ require('dotenv').config();
 
 const app = express();
 const PORT = process.env.PORT || 3000;
-const FLASK_API_URL = process.env.FLASK_API_URL || 'http://localhost:5000';
+const FLASK_API_URL = process.env.FLASK_API_URL || 'http://localhost:5001';
 
 app.use(cors());
 app.use(express.json());
@@ -49,6 +49,38 @@ app.get('/api/user-ip', (req, res) => {
              req.socket.remoteAddress ||
              'unknown';
   res.json({ status: 'success', ip });
+});
+
+// Proxy endpoint for liking tracks
+app.post('/api/tracks/like', async (req, res) => {
+  try {
+    const response = await axios.post(`${FLASK_API_URL}/api/tracks/like`, req.body, {
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      timeout: 5000
+    });
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error liking track:', error.message);
+    res.status(500).json({ status: 'error', message: 'Failed to like track' });
+  }
+});
+
+// Proxy endpoint for checking like status
+app.post('/api/tracks/is-liked', async (req, res) => {
+  try {
+    const response = await axios.post(`${FLASK_API_URL}/api/tracks/is-liked`, req.body, {
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      timeout: 5000
+    });
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error checking like status:', error.message);
+    res.status(500).json({ status: 'error', message: 'Failed to check like status' });
+  }
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
Fixes #6

The like button was changing visual state but the counter wasn't updating because the frontend was calling the Flask API directly with hardcoded localhost URLs.

## Changes
- Add proxy endpoints in Express for like feature
- Update frontend to use relative URLs
- Fix FLASK_API_URL default to port 5001

Generated with [Claude Code](https://claude.ai/code)